### PR TITLE
Respect order when exporting

### DIFF
--- a/az/bookmarks.py
+++ b/az/bookmarks.py
@@ -297,25 +297,61 @@ def _get_spaces_legacy(spaces: list) -> dict:
 
 def _convert_to_bookmarks_legacy(spaces: dict, items: list, space_titles: list[str] | None, tabs_by_space: dict) -> dict:
     bookmarks = {"bookmarks": []}
-    item_dict = {item["id"]: item for item in items if isinstance(item, dict)}
-
+    
+    # Create a dictionary for item lookup
+    # Arc's items list structure is [id1, data1, id2, data2, ...]
+    item_dict = {}
+    for i in range(0, len(items), 2):
+        if i + 1 >= len(items):
+            break
+        item_id = items[i]
+        item_data = items[i + 1]
+        if isinstance(item_data, dict):
+            item_dict[item_id] = item_data
+    
+    # Get parent-child relationships while preserving order
+    parent_child_map = {}
+    for item_id, item in item_dict.items():
+        if "childrenIds" in item and isinstance(item["childrenIds"], list):
+            # Save children in the exact order they appear in childrenIds
+            parent_child_map[item_id] = item["childrenIds"]
+    
     def recurse_into_children(parent_id: str) -> list:
         children = []
-        for item_id, item in item_dict.items():
-            if item.get("parentID") == parent_id:
-                if "data" in item and "tab" in item["data"]:
+        
+        # Get the ordered list of children for this parent
+        child_ids = parent_child_map.get(parent_id, [])
+        
+        for child_id in child_ids:
+            if child_id not in item_dict:
+                continue
+                
+            child_item = item_dict[child_id]
+            
+            # Handle bookmark/tab
+            if "data" in child_item and "tab" in child_item["data"]:
+                tab = child_item["data"]["tab"]
+                title = child_item.get("title") or tab.get("savedTitle", "")
+                url = tab.get("savedURL", "")
+                
+                if title and url:
                     children.append({
-                        "title": item.get("title") or item["data"]["tab"].get("savedTitle", ""),
+                        "title": title,
                         "type": "bookmark",
-                        "url": item["data"]["tab"].get("savedURL", ""),
+                        "url": url
                     })
-                elif "title" in item:
-                    child_folder = {
-                        "title": item["title"],
+            # Handle folders
+            elif "title" in child_item:
+                folder_title = child_item["title"]
+                folder_children = recurse_into_children(child_id)
+                
+                if folder_title and folder_children:
+                    children.append({
+                        "title": folder_title,
                         "type": "folder",
-                        "children": recurse_into_children(item_id),
-                    }
-                    children.append(child_folder)
+                        "children": folder_children
+                    })
+        
         return children
 
     for space_id, space_name in spaces["pinned"].items():

--- a/az/bookmarks.py
+++ b/az/bookmarks.py
@@ -196,6 +196,26 @@ def _extract_today_tabs_by_space(json_data: dict, spaces: dict) -> dict:
                         "type": "bookmark",
                         "url": saved_url,
                     })
+            
+            # Handle top-level splitView items (which contain tabs as children)
+            elif "splitView" in child_data:
+                splitview_children_ids = child_item.get("childrenIds", [])
+                for splitview_child_id in splitview_children_ids:
+                    if splitview_child_id not in item_dict:
+                        continue
+
+                    splitview_child = item_dict[splitview_child_id]
+                    if "data" in splitview_child and "tab" in splitview_child["data"]:
+                        tab = splitview_child["data"]["tab"]
+                        saved_title = tab.get("savedTitle", "")
+                        saved_url = tab.get("savedURL", "")
+
+                        if saved_title and saved_url:
+                            result.append({
+                                "title": saved_title,
+                                "type": "bookmark",
+                                "url": saved_url,
+                            })
 
             # Handle tabGroups (subfolders)
             elif "tabGroup" in child_data:
@@ -297,7 +317,7 @@ def _get_spaces_legacy(spaces: list) -> dict:
 
 def _convert_to_bookmarks_legacy(spaces: dict, items: list, space_titles: list[str] | None, tabs_by_space: dict) -> dict:
     bookmarks = {"bookmarks": []}
-    
+
     # Create a dictionary for item lookup
     # Arc's items list structure is [id1, data1, id2, data2, ...]
     item_dict = {}
@@ -308,32 +328,32 @@ def _convert_to_bookmarks_legacy(spaces: dict, items: list, space_titles: list[s
         item_data = items[i + 1]
         if isinstance(item_data, dict):
             item_dict[item_id] = item_data
-    
+
     # Get parent-child relationships while preserving order
     parent_child_map = {}
     for item_id, item in item_dict.items():
         if "childrenIds" in item and isinstance(item["childrenIds"], list):
             # Save children in the exact order they appear in childrenIds
             parent_child_map[item_id] = item["childrenIds"]
-    
+
     def recurse_into_children(parent_id: str) -> list:
         children = []
-        
+
         # Get the ordered list of children for this parent
         child_ids = parent_child_map.get(parent_id, [])
-        
+
         for child_id in child_ids:
             if child_id not in item_dict:
                 continue
-                
+
             child_item = item_dict[child_id]
-            
+
             # Handle bookmark/tab
             if "data" in child_item and "tab" in child_item["data"]:
                 tab = child_item["data"]["tab"]
                 title = child_item.get("title") or tab.get("savedTitle", "")
                 url = tab.get("savedURL", "")
-                
+
                 if title and url:
                     children.append({
                         "title": title,
@@ -344,14 +364,14 @@ def _convert_to_bookmarks_legacy(spaces: dict, items: list, space_titles: list[s
             elif "title" in child_item:
                 folder_title = child_item["title"]
                 folder_children = recurse_into_children(child_id)
-                
+
                 if folder_title and folder_children:
                     children.append({
                         "title": folder_title,
                         "type": "folder",
                         "children": folder_children
                     })
-        
+
         return children
 
     for space_id, space_name in spaces["pinned"].items():

--- a/az/bookmarks.py
+++ b/az/bookmarks.py
@@ -360,6 +360,26 @@ def _convert_to_bookmarks_legacy(spaces: dict, items: list, space_titles: list[s
                         "type": "bookmark",
                         "url": url
                     })
+            # Handle split view items (which contain tabs as children)
+            elif "data" in child_item and "splitView" in child_item["data"]:
+                # Process tabs within the split view
+                splitview_children_ids = child_item.get("childrenIds", [])
+                for splitview_child_id in splitview_children_ids:
+                    if splitview_child_id not in item_dict:
+                        continue
+
+                    splitview_child = item_dict[splitview_child_id]
+                    if "data" in splitview_child and "tab" in splitview_child["data"]:
+                        tab = splitview_child["data"]["tab"]
+                        title = splitview_child.get("title") or tab.get("savedTitle", "")
+                        url = tab.get("savedURL", "")
+
+                        if title and url:
+                            children.append({
+                                "title": title,
+                                "type": "bookmark",
+                                "url": url
+                            })
             # Handle folders
             elif "title" in child_item:
                 folder_title = child_item["title"]

--- a/az/bookmarks.py
+++ b/az/bookmarks.py
@@ -196,7 +196,7 @@ def _extract_today_tabs_by_space(json_data: dict, spaces: dict) -> dict:
                         "type": "bookmark",
                         "url": saved_url,
                     })
-            
+
             # Handle top-level splitView items (which contain tabs as children)
             elif "splitView" in child_data:
                 splitview_children_ids = child_item.get("childrenIds", [])


### PR DESCRIPTION
Followup change which correctly maintains tab and folder order, while still supporting split tabs